### PR TITLE
Randomize table names on tests for SPEED

### DIFF
--- a/.buildkite/docker.sh
+++ b/.buildkite/docker.sh
@@ -13,7 +13,7 @@ docker run --name test-mssql --network test-net \
 docker run -w /build --network test-net -v $BUILDKITE_BUILD_CHECKOUT_PATH:/build \
     -e RUSTFLAGS="-D warnings" \
     -e TIBERIUS_TEST_CONNECTION_STRING="server=tcp:test-mssql,1433;user=SA;password=$MSSQL_SA_PASSWORD;TrustServerCertificate=true" \
-    prismagraphql/build:test cargo test $1 -- --test-threads=1
+    prismagraphql/build:test cargo test $1
 
 exit_code=$?
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,4 +20,4 @@ install:
 build: false
 
 test_script:
-  - cargo test --target %TARGET% --all -- --test-threads=1
+  - cargo test --target %TARGET% --all

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -34,6 +34,7 @@ pin-project-lite = "0.1"
 futures_codec = "0.4"
 futures-sink = "0.3"
 env_logger = "0.7"
+names = "0.11"
 
 [dev-dependencies.chrono]
 version = "0.4"

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -1,4 +1,6 @@
-use futures_util::{TryStreamExt, StreamExt};
+use futures::lock::Mutex;
+use futures_util::{StreamExt, TryStreamExt};
+use names::{Generator, Name};
 use once_cell::sync::Lazy;
 use std::env;
 use std::sync::Once;
@@ -13,6 +15,13 @@ static CONN_STR: Lazy<String> = Lazy::new(|| {
     env::var("TIBERIUS_TEST_CONNECTION_STRING")
         .unwrap_or_else(|_| "server=tcp:localhost,1433;TrustServerCertificate=true".to_owned())
 });
+
+static NAMES: Lazy<Mutex<Generator>> =
+    Lazy::new(|| Mutex::new(Generator::with_naming(Name::Plain)));
+
+async fn random_table() -> String {
+    NAMES.lock().await.next().unwrap().replace('-', "")
+}
 
 macro_rules! test_on_runtimes {
     ($code:ident, $connstr:expr) => {
@@ -107,8 +116,6 @@ macro_rules! test_on_runtimes {
     };
 }
 
-
-
 #[cfg(feature = "tls")]
 test_on_runtimes! { connect_with_full_encryption, &format!("{};encrypt=true", *CONN_STR)}
 
@@ -125,10 +132,9 @@ where
     Ok(())
 }
 
-
 #[cfg(windows)]
-test_on_runtimes! { 
-    connect_to_named_instance, 
+test_on_runtimes! {
+    connect_to_named_instance,
     &{
         let instance_name = env::var("TIBERIUS_TEST_INSTANCE").unwrap_or("MSSQLSERVER".to_owned());
         CONN_STR.replace(",1433", &format!("\\{}", instance_name))
@@ -149,26 +155,33 @@ where
 }
 
 test_on_runtimes! { test_kanji_varchars }
-async fn test_kanji_varchars<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn test_kanji_varchars<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
-    conn.execute("CREATE TABLE ##TestKanji (content NVARCHAR(max))", &[])
-        .await?;
+    let table = random_table().await;
+
+    conn.execute(
+        format!("CREATE TABLE ##{} (content NVARCHAR(max))", table),
+        &[],
+    )
+    .await?;
 
     let kanji = "余ったものを後で皆に分けようと思っていただけなのに".to_string();
     let long_kanji = "余".repeat(80001);
 
     let res = conn
         .execute(
-            "INSERT INTO ##TestKanji (content) VALUES (@P1), (@P2)",
+            format!("INSERT INTO ##{} (content) VALUES (@P1), (@P2)", table),
             &[&kanji, &long_kanji],
         )
         .await?;
 
     assert_eq!(2, res.total());
 
-    let stream = conn.query("SELECT content FROM ##TestKanji", &[]).await?;
+    let stream = conn
+        .query(format!("SELECT content FROM ##{}", table), &[])
+        .await?;
 
     let results: Vec<String> = stream
         .map_ok(|r| r.get::<_, String>(0))
@@ -181,25 +194,32 @@ where
 }
 
 test_on_runtimes! { read_and_write_finnish_varchars }
-async fn read_and_write_finnish_varchars<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn read_and_write_finnish_varchars<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
-    conn.execute("CREATE TABLE ##TestFinnish (content NVARCHAR(max))", &[])
-        .await?;
+    let table = random_table().await;
+
+    conn.execute(
+        format!("CREATE TABLE ##{} (content NVARCHAR(max))", table),
+        &[],
+    )
+    .await?;
 
     let kalevala = "Vaka vanha Väinämöinen / elelevi aikojansa / noilla Väinölän ahoilla, Kalevalan kankahilla.";
 
     let res = conn
         .execute(
-            "INSERT INTO ##TestFinnish (content) VALUES (@P1)",
+            format!("INSERT INTO ##{} (content) VALUES (@P1)", table),
             &[&kalevala],
         )
         .await?;
 
     assert_eq!(1, res.total());
 
-    let stream = conn.query("SELECT content FROM ##TestFinnish", &[]).await?;
+    let stream = conn
+        .query(format!("SELECT content FROM ##{}", table), &[])
+        .await?;
 
     let results: Vec<String> = stream
         .map_ok(|r| r.get::<_, String>(0))
@@ -212,17 +232,18 @@ where
 }
 
 test_on_runtimes! { execute_insert_update_delete }
-async fn execute_insert_update_delete<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn execute_insert_update_delete<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
+    let table = random_table().await;
 
-    conn.execute("CREATE TABLE ##TestExecute (id int)", &[])
+    conn.execute(format!("CREATE TABLE ##{} (id int)", table), &[])
         .await?;
 
     let insert_count = conn
         .execute(
-            "INSERT INTO ##TestExecute (id) VALUES (@P1), (@P2), (@P3)",
+            format!("INSERT INTO ##{} (id) VALUES (@P1), (@P2), (@P3)", table),
             &[&1i32, &2i32, &3i32],
         )
         .await?
@@ -232,7 +253,7 @@ where
 
     let update_count = conn
         .execute(
-            "UPDATE ##TestExecute SET id = @P1 WHERE id = @P2",
+            format!("UPDATE ##{} SET id = @P1 WHERE id = @P2", table),
             &[&2i32, &1i32],
         )
         .await?
@@ -241,7 +262,7 @@ where
     assert_eq!(1, update_count);
 
     let delete_count = conn
-        .execute("DELETE ##TestExecute WHERE id <> @P1", &[&3i32])
+        .execute(format!("DELETE ##{} WHERE id <> @P1", table), &[&3i32])
         .await?
         .total();
 
@@ -251,17 +272,18 @@ where
 }
 
 test_on_runtimes! { execute_with_multiple_separate_results }
-async fn execute_with_multiple_separate_results<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn execute_with_multiple_separate_results<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
+    let table = random_table().await;
 
-    conn.execute("CREATE TABLE ##TestExecuteMultiple1 (id int)", &[])
+    conn.execute(format!("CREATE TABLE ##{} (id int)", table), &[])
         .await?;
 
     let insert_count = conn
         .execute(
-            "INSERT INTO ##TestExecuteMultiple1 (id) VALUES (@P1); INSERT INTO ##TestExecuteMultiple1 (id) VALUES (@P2), (@P3);",
+            format!("INSERT INTO ##{table} (id) VALUES (@P1); INSERT INTO ##{table} (id) VALUES (@P2), (@P3);", table = table),
             &[&1i32, &2i32, &3i32],
         )
         .await?;
@@ -273,17 +295,21 @@ where
 }
 
 test_on_runtimes! { execute_multiple_count_total }
-async fn execute_multiple_count_total<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn execute_multiple_count_total<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
+    let table = random_table().await;
 
-    conn.execute("CREATE TABLE ##TestExecuteMultiple2 (id int)", &[])
+    conn.execute(format!("CREATE TABLE ##{} (id int)", table), &[])
         .await?;
 
     let insert_count = conn
         .execute(
-            "INSERT INTO ##TestExecuteMultiple2 (id) VALUES (@P1); INSERT INTO ##TestExecuteMultiple2 (id) VALUES (@P2), (@P3);",
+            format!(
+                "INSERT INTO ##{table} (id) VALUES (@P1); INSERT INTO ##{table} (id) VALUES (@P2), (@P3);",
+                table = table
+            ),
             &[&1i32, &2i32, &3i32],
         )
         .await?;
@@ -295,11 +321,10 @@ where
 }
 
 test_on_runtimes! { correct_row_handling_when_not_enough_data }
-async fn correct_row_handling_when_not_enough_data<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn correct_row_handling_when_not_enough_data<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
-
     let mut stream = conn
         .query(
             "SELECT @P1; SELECT @P2;",
@@ -328,7 +353,7 @@ where
 }
 
 test_on_runtimes! { multiple_stored_procedure_functions }
-async fn multiple_stored_procedure_functions<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn multiple_stored_procedure_functions<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
@@ -350,11 +375,10 @@ where
 }
 
 test_on_runtimes! { multiple_queries }
-async fn multiple_queries<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn multiple_queries<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
-
     let mut stream = conn
         .query("SELECT 'a' AS first; SELECT 'b' AS second;", &[])
         .await?;
@@ -386,11 +410,10 @@ where
 }
 
 test_on_runtimes! { bool_type }
-async fn bool_type<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn bool_type<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
-
     let mut stream = conn
         .query("SELECT @P1, @P2 ORDER BY 1", &[&false, &false])
         .await?;
@@ -408,7 +431,7 @@ where
 }
 
 test_on_runtimes! { i8_token }
-async fn i8_token<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn i8_token<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
@@ -420,7 +443,7 @@ where
 }
 
 test_on_runtimes! { i16_token }
-async fn i16_token<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn i16_token<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
@@ -432,7 +455,7 @@ where
 }
 
 test_on_runtimes! { i32_token }
-async fn i32_token<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn i32_token<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
@@ -444,7 +467,7 @@ where
 }
 
 test_on_runtimes! { i64_token }
-async fn i64_token<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn i64_token<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
@@ -455,9 +478,8 @@ where
     Ok(())
 }
 
-
 test_on_runtimes! { f32_token }
-async fn f32_token<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn f32_token<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
@@ -468,9 +490,8 @@ where
     Ok(())
 }
 
-
 test_on_runtimes! { f64_token }
-async fn f64_token<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn f64_token<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
@@ -481,9 +502,8 @@ where
     Ok(())
 }
 
-
 test_on_runtimes! { short_strings }
-async fn short_strings<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn short_strings<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
@@ -494,9 +514,8 @@ where
     Ok(())
 }
 
-
 test_on_runtimes! { long_strings }
-async fn long_strings<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn long_strings<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
@@ -508,9 +527,8 @@ where
     Ok(())
 }
 
-
 test_on_runtimes! { stored_procedures }
-async fn stored_procedures<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn stored_procedures<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
@@ -525,13 +543,13 @@ where
     Ok(())
 }
 
-
 test_on_runtimes! { drop_stream_before_handling_all_results_should_not_cause_weird_things }
-async fn drop_stream_before_handling_all_results_should_not_cause_weird_things<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn drop_stream_before_handling_all_results_should_not_cause_weird_things<S>(
+    mut conn: tiberius::Client<S>,
+) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
-
     {
         let stream = conn
             .query(
@@ -557,9 +575,8 @@ where
     Ok(())
 }
 
-
 test_on_runtimes! { nbc_rows }
-async fn nbc_rows<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn nbc_rows<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
@@ -599,25 +616,30 @@ where
     Ok(())
 }
 
-
 test_on_runtimes! { ntext_type }
-async fn ntext_type<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn ntext_type<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
+    let table = random_table().await;
 
     let string = r#"Hääpuhetta voi värittää kertomalla vitsejä, aforismeja,
         sananlaskuja, laulunsäkeitä ja muita lainauksia. Huumori sopii hääpuheeseen,
         mutta vitsit eivät saa loukata. Häissä ensimmäisen juhlapuheen pitää
         perinteisesti morsiamen isä."#;
 
-    conn.execute("CREATE TABLE ##TestNText (content NTEXT)", &[])
+    conn.execute(format!("CREATE TABLE ##{} (content NTEXT)", table), &[])
         .await?;
 
-    conn.execute("INSERT INTO ##TestNText (content) VALUES (@P1)", &[&string])
-        .await?;
+    conn.execute(
+        format!("INSERT INTO ##{} (content) VALUES (@P1)", table),
+        &[&string],
+    )
+    .await?;
 
-    let stream = conn.query("SELECT content FROM ##TestNText", &[]).await?;
+    let stream = conn
+        .query(format!("SELECT content FROM ##{}", table), &[])
+        .await?;
 
     let rows: Vec<String> = stream
         .map_ok(|x| x.get::<_, String>(0))
@@ -629,24 +651,24 @@ where
     Ok(())
 }
 
-
 test_on_runtimes! { ntext_empty }
-async fn ntext_empty<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn ntext_empty<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
+    let table = random_table().await;
 
-    conn.execute("CREATE TABLE ##TestNTextEmpty (content NTEXT)", &[])
+    conn.execute(format!("CREATE TABLE ##{} (content NTEXT)", table), &[])
         .await?;
 
     conn.execute(
-        "INSERT INTO ##TestNTextEmpty (content) VALUES (@P1)",
+        format!("INSERT INTO ##{} (content) VALUES (@P1)", table),
         &[&Option::<String>::None],
     )
     .await?;
 
     let mut stream = conn
-        .query("SELECT content FROM ##TestNTextEmpty", &[])
+        .query(format!("SELECT content FROM ##{}", table), &[])
         .await?;
 
     let mut rows: Vec<Option<String>> = Vec::new();
@@ -661,25 +683,26 @@ where
     Ok(())
 }
 
-
 test_on_runtimes! { text_type }
-async fn text_type<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn text_type<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
-
+    let table = random_table().await;
     let string = "a".repeat(10000);
 
-    conn.execute("CREATE TABLE ##TestText (content TEXT)", &[])
+    conn.execute(format!("CREATE TABLE ##{} (content TEXT)", table), &[])
         .await?;
 
     conn.execute(
-        "INSERT INTO ##TestText (content) VALUES (@P1)",
+        format!("INSERT INTO ##{} (content) VALUES (@P1)", table),
         &[&string.as_str()],
     )
     .await?;
 
-    let stream = conn.query("SELECT content FROM ##TestText", &[]).await?;
+    let stream = conn
+        .query(format!("SELECT content FROM ##{}", table), &[])
+        .await?;
 
     let rows: Vec<String> = stream
         .map_ok(|x| x.get::<_, String>(0))
@@ -691,24 +714,24 @@ where
     Ok(())
 }
 
-
 test_on_runtimes! { text_empty }
-async fn text_empty<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn text_empty<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
+    let table = random_table().await;
 
-    conn.execute("CREATE TABLE ##TestTextEmpty (content TEXT)", &[])
+    conn.execute(format!("CREATE TABLE ##{} (content TEXT)", table), &[])
         .await?;
 
     conn.execute(
-        "INSERT INTO ##TestTextEmpty (content) VALUES (@P1)",
+        format!("INSERT INTO ##{} (content) VALUES (@P1)", table),
         &[&Option::<String>::None],
     )
     .await?;
 
     let mut stream = conn
-        .query("SELECT content FROM ##TestTextEmpty", &[])
+        .query(format!("SELECT content FROM ##{}", table), &[])
         .await?;
 
     let mut rows: Vec<Option<String>> = Vec::new();
@@ -723,22 +746,22 @@ where
     Ok(())
 }
 
-
 test_on_runtimes! { varbinary_empty }
-async fn varbinary_empty<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn varbinary_empty<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
+    let table = random_table().await;
 
     conn.execute(
-        "CREATE TABLE ##TestVarBinaryEmpty (content VARBINARY(max))",
+        format!("CREATE TABLE ##{} (content VARBINARY(max))", table),
         &[],
     )
     .await?;
 
     let total = conn
         .execute(
-            "INSERT INTO ##TestVarBinaryEmpty (content) VALUES (@P1)",
+            format!("INSERT INTO ##{} (content) VALUES (@P1)", table),
             &[&Option::<Vec<u8>>::None],
         )
         .await?
@@ -747,7 +770,7 @@ where
     assert_eq!(1, total);
 
     let mut stream = conn
-        .query("SELECT content FROM ##TestVarBinaryEmpty", &[])
+        .query(format!("SELECT content FROM ##{}", table), &[])
         .await?;
 
     let mut rows: Vec<Option<Vec<u8>>> = Vec::new();
@@ -762,22 +785,25 @@ where
     Ok(())
 }
 
-
 test_on_runtimes! { binary_type }
-async fn binary_type<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn binary_type<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
+    let table = random_table().await;
 
-    conn.execute("CREATE TABLE ##TestBinary (content BINARY(8000))", &[])
-        .await?;
+    conn.execute(
+        format!("CREATE TABLE ##{} (content BINARY(8000))", table),
+        &[],
+    )
+    .await?;
 
     let mut binary = vec![0; 7999];
     binary.push(5);
 
     let inserted = conn
         .execute(
-            "INSERT INTO ##TestBinary (content) VALUES (@P1)",
+            format!("INSERT INTO ##{} (content) VALUES (@P1)", table),
             &[&binary.as_slice()],
         )
         .await?
@@ -785,7 +811,9 @@ where
 
     assert_eq!(1, inserted);
 
-    let mut stream = conn.query("SELECT content FROM ##TestBinary", &[]).await?;
+    let mut stream = conn
+        .query(format!("SELECT content FROM ##{}", table), &[])
+        .await?;
 
     let mut rows: Vec<Vec<u8>> = Vec::new();
     while let Some(row) = stream.try_next().await? {
@@ -799,22 +827,25 @@ where
     Ok(())
 }
 
-
 test_on_runtimes! { varbinary_type }
-async fn varbinary_type<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn varbinary_type<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
+    let table = random_table().await;
 
-    conn.execute("CREATE TABLE ##VarBinary (content VARBINARY(8000))", &[])
-        .await?;
+    conn.execute(
+        format!("CREATE TABLE ##{} (content VARBINARY(8000))", table),
+        &[],
+    )
+    .await?;
 
     let mut binary = vec![0; 79];
     binary.push(5);
 
     let inserted = conn
         .execute(
-            "INSERT INTO ##VarBinary (content) VALUES (@P1)",
+            format!("INSERT INTO ##{} (content) VALUES (@P1)", table),
             &[&binary.as_slice()],
         )
         .await?
@@ -822,7 +853,9 @@ where
 
     assert_eq!(1, inserted);
 
-    let mut stream = conn.query("SELECT content FROM ##VarBinary", &[]).await?;
+    let mut stream = conn
+        .query(format!("SELECT content FROM ##{}", table), &[])
+        .await?;
 
     let mut rows: Vec<Vec<u8>> = Vec::new();
     while let Some(row) = stream.try_next().await? {
@@ -835,15 +868,15 @@ where
 
     Ok(())
 }
-
 
 test_on_runtimes! { image_type }
-async fn image_type<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn image_type<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
+    let table = random_table().await;
 
-    conn.execute("CREATE TABLE ##ImageType (content IMAGE)", &[])
+    conn.execute(format!("CREATE TABLE ##{} (content IMAGE)", table), &[])
         .await?;
 
     let mut binary = vec![0; 79];
@@ -851,7 +884,7 @@ where
 
     let inserted = conn
         .execute(
-            "INSERT INTO ##ImageType (content) VALUES (@P1)",
+            format!("INSERT INTO ##{} (content) VALUES (@P1)", table),
             &[&binary.as_slice()],
         )
         .await?
@@ -859,7 +892,9 @@ where
 
     assert_eq!(1, inserted);
 
-    let mut stream = conn.query("SELECT content FROM ##ImageType", &[]).await?;
+    let mut stream = conn
+        .query(format!("SELECT content FROM ##{}", table), &[])
+        .await?;
 
     let mut rows: Vec<Vec<u8>> = Vec::new();
     while let Some(row) = stream.try_next().await? {
@@ -873,9 +908,8 @@ where
     Ok(())
 }
 
-
 test_on_runtimes! { guid_type }
-async fn guid_type<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn guid_type<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
@@ -889,22 +923,25 @@ where
     Ok(())
 }
 
-
 test_on_runtimes! { varbinary_max }
-async fn varbinary_max<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn varbinary_max<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
+    let table = random_table().await;
 
-    conn.execute("CREATE TABLE ##MaxBinary (content VARBINARY(max))", &[])
-        .await?;
+    conn.execute(
+        format!("CREATE TABLE ##{} (content VARBINARY(max))", table),
+        &[],
+    )
+    .await?;
 
     let mut binary = vec![0; 8000];
     binary.push(5);
 
     let inserted = conn
         .execute(
-            "INSERT INTO ##MaxBinary (content) VALUES (@P1)",
+            format!("INSERT INTO ##{} (content) VALUES (@P1)", table),
             &[&binary.as_slice()],
         )
         .await?
@@ -912,7 +949,9 @@ where
 
     assert_eq!(1, inserted);
 
-    let mut stream = conn.query("SELECT content FROM ##MaxBinary", &[]).await?;
+    let mut stream = conn
+        .query(format!("SELECT content FROM ##{}", table), &[])
+        .await?;
 
     let mut rows: Vec<Vec<u8>> = Vec::new();
     while let Some(row) = stream.try_next().await? {
@@ -926,9 +965,8 @@ where
     Ok(())
 }
 
-
 test_on_runtimes! { numeric_type_u32_presentation }
-async fn numeric_type_u32_presentation<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn numeric_type_u32_presentation<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
@@ -945,9 +983,8 @@ where
     Ok(())
 }
 
-
 test_on_runtimes! { numeric_type_u64_presentation }
-async fn numeric_type_u64_presentation<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn numeric_type_u64_presentation<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
@@ -964,9 +1001,8 @@ where
     Ok(())
 }
 
-
 test_on_runtimes! { numeric_type_u96_presentation }
-async fn numeric_type_u96_presentation<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn numeric_type_u96_presentation<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
@@ -983,9 +1019,8 @@ where
     Ok(())
 }
 
-
 test_on_runtimes! { numeric_type_u128_presentation }
-async fn numeric_type_u128_presentation<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn numeric_type_u128_presentation<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
@@ -1002,12 +1037,11 @@ where
     Ok(())
 }
 
-
-#[cfg(feature = "rust_decimal")] 
+#[cfg(feature = "rust_decimal")]
 test_on_runtimes! { decimal_type_u32_presentation }
 
-#[cfg(feature = "rust_decimal")] 
-async fn decimal_type_u32_presentation<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+#[cfg(feature = "rust_decimal")]
+async fn decimal_type_u32_presentation<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
@@ -1026,12 +1060,11 @@ where
     Ok(())
 }
 
-
 #[cfg(feature = "rust_decimal")]
 test_on_runtimes! { decimal_type_u64_presentation }
 
 #[cfg(feature = "rust_decimal")]
-async fn decimal_type_u64_presentation<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn decimal_type_u64_presentation<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
@@ -1050,12 +1083,11 @@ where
     Ok(())
 }
 
-
 #[cfg(feature = "rust_decimal")]
 test_on_runtimes! { decimal_type_u96_presentation }
 
 #[cfg(feature = "rust_decimal")]
-async fn decimal_type_u96_presentation<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn decimal_type_u96_presentation<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
@@ -1074,12 +1106,11 @@ where
     Ok(())
 }
 
-
 #[cfg(feature = "rust_decimal")]
 test_on_runtimes! { decimal_type_u128_presentation }
 
 #[cfg(feature = "rust_decimal")]
-async fn decimal_type_u128_presentation<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn decimal_type_u128_presentation<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
@@ -1098,27 +1129,35 @@ where
     Ok(())
 }
 
-
 #[cfg(all(feature = "chrono", feature = "tds73"))]
 test_on_runtimes! { naive_small_date_time_tds73 }
 
 #[cfg(all(feature = "chrono", feature = "tds73"))]
-async fn naive_small_date_time_tds73<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn naive_small_date_time_tds73<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
     use chrono::{NaiveDate, NaiveDateTime};
 
     let dt = NaiveDate::from_ymd(2020, 4, 20).and_hms(16, 20, 0);
+    let table = random_table().await;
 
-    conn.execute("CREATE TABLE ##TestSmallDt (date smalldatetime)", &[])
+    conn.execute(
+        format!("CREATE TABLE ##{} (date smalldatetime)", table),
+        &[],
+    )
+    .await?;
+
+    conn.execute(
+        format!("INSERT INTO ##{} (date) VALUES (@P1)", table),
+        &[&dt],
+    )
+    .await?
+    .total();
+
+    let stream = conn
+        .query(format!("SELECT date FROM ##{}", table), &[])
         .await?;
-
-    conn.execute("INSERT INTO ##TestSmallDt (date) VALUES (@P1)", &[&dt])
-        .await?
-        .total();
-
-    let stream = conn.query("SELECT date FROM ##TestSmallDt", &[]).await?;
 
     let rows: Vec<_> = stream
         .map_ok(|x| x.get::<_, NaiveDateTime>(0))
@@ -1128,28 +1167,33 @@ where
     assert_eq!(dt, rows[0]);
     Ok(())
 }
-
 
 #[cfg(all(feature = "chrono", feature = "tds73"))]
 test_on_runtimes! { naive_date_time2_tds73 }
 
 #[cfg(all(feature = "chrono", feature = "tds73"))]
-async fn naive_date_time2_tds73<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn naive_date_time2_tds73<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
     use chrono::{NaiveDate, NaiveDateTime};
 
     let dt = NaiveDate::from_ymd(2020, 4, 20).and_hms(16, 20, 0);
+    let table = random_table().await;
 
-    conn.execute("CREATE TABLE ##NaiveDateTime2 (date datetime2)", &[])
+    conn.execute(format!("CREATE TABLE ##{} (date datetime2)", table), &[])
         .await?;
 
-    conn.execute("INSERT INTO ##NaiveDateTime2 (date) VALUES (@P1)", &[&dt])
-        .await?
-        .total();
+    conn.execute(
+        format!("INSERT INTO ##{} (date) VALUES (@P1)", table),
+        &[&dt],
+    )
+    .await?
+    .total();
 
-    let stream = conn.query("SELECT date FROM ##NaiveDateTime2", &[]).await?;
+    let stream = conn
+        .query(format!("SELECT date FROM ##{}", table), &[])
+        .await?;
 
     let rows: Vec<_> = stream
         .map_ok(|x| x.get::<_, NaiveDateTime>(0))
@@ -1160,13 +1204,11 @@ where
     Ok(())
 }
 
-
-
 #[cfg(all(feature = "chrono", not(feature = "tds73")))]
 test_on_runtimes! { naive_date_time_tds72 }
 
 #[cfg(all(feature = "chrono", not(feature = "tds73")))]
-async fn naive_date_time_tds72<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn naive_date_time_tds72<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
@@ -1185,12 +1227,11 @@ where
     Ok(())
 }
 
-
 #[cfg(all(feature = "chrono", feature = "tds73"))]
 test_on_runtimes! { naive_time }
 
 #[cfg(all(feature = "chrono", feature = "tds73"))]
-async fn naive_time<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn naive_time<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
@@ -1209,12 +1250,11 @@ where
     Ok(())
 }
 
-
 #[cfg(all(feature = "chrono", feature = "tds73"))]
 test_on_runtimes! { naive_date }
 
 #[cfg(all(feature = "chrono", feature = "tds73"))]
-async fn naive_date<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn naive_date<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
@@ -1233,12 +1273,11 @@ where
     Ok(())
 }
 
-
 #[cfg(all(feature = "chrono", feature = "tds73"))]
 test_on_runtimes! { date_time_utc }
 
 #[cfg(all(feature = "chrono", feature = "tds73"))]
-async fn date_time_utc<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn date_time_utc<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
@@ -1258,12 +1297,11 @@ where
     Ok(())
 }
 
-
 #[cfg(all(feature = "chrono", feature = "tds73"))]
 test_on_runtimes! { date_time_fixed }
 
 #[cfg(all(feature = "chrono", feature = "tds73"))]
-async fn date_time_fixed<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn date_time_fixed<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
@@ -1284,13 +1322,11 @@ where
     Ok(())
 }
 
-
 test_on_runtimes! { xml_read_write }
-async fn xml_read_write<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn xml_read_write<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {
-
     let xml = XmlData::new("<root><child attr=\"attr-value\"/></root>");
     let stream = conn.query("SELECT @P1", &[&xml]).await?;
 
@@ -1304,9 +1340,8 @@ where
     Ok(())
 }
 
-
 test_on_runtimes! { xml_read_null_xml }
-async fn xml_read_null_xml<S>(mut conn: tiberius::Client<S>) -> Result<()> 
+async fn xml_read_null_xml<S>(mut conn: tiberius::Client<S>) -> Result<()>
 where
     S: futures::AsyncRead + futures::AsyncWrite + Unpin,
 {


### PR DESCRIPTION
This enables us to run multiple tests in parallel.